### PR TITLE
feat: surface canonical YouTube IDs (channelId, browseId) in search results

### DIFF
--- a/tutubo/models.py
+++ b/tutubo/models.py
@@ -214,6 +214,21 @@ class VideoPreview(YoutubePreview):
             return ""
 
     @property
+    def channel_id(self) -> str:
+        """Canonical channel id (``UCxxx…``) of the uploader, or '' if missing.
+
+        Pulled from the renderer's ``browseId`` rather than parsed from
+        ``channel_url`` — the renderer always carries the canonical id
+        regardless of whether the channel publishes a custom ``/@handle``
+        or ``/c/name`` URL.
+        """
+        try:
+            return self._raw_data['ownerText']['runs'][0][
+                'navigationEndpoint']['browseEndpoint']['browseId']
+        except (KeyError, IndexError, TypeError):
+            return ""
+
+    @property
     def channel_thumbnail_url(self) -> str:
         """Channel avatar URL, available directly from search results."""
         thumbs = (self._raw_data
@@ -349,6 +364,7 @@ class VideoPreview(YoutubePreview):
     def as_dict(self) -> dict:
         return {
             'videoId': self.video_id,
+            'channelId': self.channel_id,
             'title': self.title,
             'author': self.author,
             'channel_url': self.channel_url,

--- a/tutubo/ytmus.py
+++ b/tutubo/ytmus.py
@@ -84,6 +84,29 @@ class MusicTrack(YTMusicResult):
         return self._raw_data.get("videoId", "")
 
     @property
+    def artist_browse_id(self) -> str:
+        """Canonical artist ``browseId`` (typically ``UCxxx…``).
+
+        Empty string when the result didn't carry one — common for video-
+        type results where the uploader is just a channel, not a music
+        artist entity.
+        """
+        artists = self._raw_data.get("artists")
+        if isinstance(artists, list) and artists:
+            a = artists[0] or {}
+            if isinstance(a, dict):
+                return a.get("id") or a.get("browseId") or ""
+        return ""
+
+    @property
+    def album_browse_id(self) -> str:
+        """Canonical album ``browseId`` (``MPREb_xxx``), empty if missing."""
+        raw = self._raw_data.get("album")
+        if isinstance(raw, dict):
+            return raw.get("id") or raw.get("browseId") or ""
+        return ""
+
+    @property
     def length(self) -> Optional[int]:
         """Duration in seconds, or None if unknown."""
         secs = self._raw_data.get("duration_seconds")
@@ -154,6 +177,8 @@ class MusicTrack(YTMusicResult):
     def as_dict(self) -> dict:
         return {
             "videoId": self.video_id,
+            "artistBrowseId": self.artist_browse_id,
+            "albumBrowseId": self.album_browse_id,
             "title": self.title,
             "artist": self.artist,
             "album": self.album,
@@ -194,6 +219,25 @@ class MusicPlaylist(YTMusicResult):
         return self._raw_data.get("audioPlaylistId") or self._raw_data.get("playlistId", "")
 
     @property
+    def browse_id(self) -> str:
+        """Canonical entity ``browseId`` for this playlist/album.
+
+        For albums this is an ``MPREb_xxx`` release-group entity id; for
+        regular playlists it's the playlist id itself.
+        """
+        return self._raw_data.get("browseId") or ""
+
+    @property
+    def artist_browse_id(self) -> str:
+        """Primary artist's canonical ``browseId``, empty if absent."""
+        artists = self._raw_data.get("artists")
+        if isinstance(artists, list) and artists:
+            a = artists[0] or {}
+            if isinstance(a, dict):
+                return a.get("id") or a.get("browseId") or ""
+        return ""
+
+    @property
     def playlist_url(self) -> str:
         pid = self.playlist_id
         return f"https://music.youtube.com/playlist?list={pid}" if pid else ""
@@ -227,6 +271,9 @@ class MusicPlaylist(YTMusicResult):
     @property
     def as_dict(self) -> dict:
         return {
+            "browseId": self.browse_id,
+            "playlistId": self.playlist_id,
+            "artistBrowseId": self.artist_browse_id,
             "title": self.title,
             "artist": self.artist,
             "year": self.year,
@@ -289,6 +336,30 @@ class MusicArtist(YTMusicResult):
         return self.name
 
     @property
+    def browse_id(self) -> str:
+        """Canonical artist ``browseId`` (``UCxxx…``).
+
+        For YT Music artists this is the same value as the artist's
+        YouTube channel id, but it identifies the artist *entity* in YT
+        Music's catalog — distinct from a regular YouTube channel that
+        merely happens to upload music.
+        """
+        return (self._raw_data.get("browseId")
+                or self._raw_data.get("channelId")
+                or "")
+
+    @property
+    def channel_id(self) -> str:
+        """Alias for :attr:`browse_id` — YT Music artist browseIds are
+        ``UCxxx`` channel ids."""
+        return self.browse_id
+
+    @property
+    def channel_url(self) -> str:
+        bid = self.browse_id
+        return f"https://music.youtube.com/channel/{bid}" if bid else ""
+
+    @property
     def subscribers(self) -> str:
         """Subscriber count label, e.g. '1.2M subscribers'."""
         return self._raw_data.get("subscribers") or self._raw_data.get("views", "")
@@ -307,8 +378,11 @@ class MusicArtist(YTMusicResult):
     @property
     def as_dict(self) -> dict:
         return {
+            "browseId": self.browse_id,
+            "channelId": self.channel_id,
             "artist": self.name,
             "image": self.thumbnail_url,
+            "url": self.channel_url,
             "subscribers": self.subscribers,
             "description": self.description,
             "playlist": [t.as_dict for t in self.tracks],


### PR DESCRIPTION
## Summary
- \`VideoPreview\` now exposes \`channel_id\` (UC-style id from renderer's \`browseId\`) and includes \`channelId\` in \`as_dict()\`
- \`MusicTrack\` now exposes \`artist_browse_id\` and \`album_browse_id\` properties, included in \`as_dict()\` as \`artistBrowseId\` / \`albumBrowseId\`
- \`MusicPlaylist\` now exposes \`browse_id\` and \`artist_browse_id\`
- \`MusicArtist\` now exposes \`browse_id\`, \`channel_id\`, and \`channel_url\`; \`as_dict()\` includes \`browseId\`, \`channelId\`, and \`url\`

## Why
YouTube Music browseIds are stable canonical identifiers for artists, albums, and channels. Downstream consumers (e.g. metarr) need real IDs rather than display-name-derived URLs.

## Test plan
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.ai/claude-code)