### PR TITLE
feat: route HTTP through unblock_requests (pre-emptive anti-bot)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest", "vcrpy", "pytest-vcr"]
-stealth = ["curl-cffi"]
+stealth = ["curl-cffi", "unblock_requests"]
 
 [project.urls]
 Homepage = "https://github.com/OpenJarbas/tutubo"

--- a/tutubo/transport.py
+++ b/tutubo/transport.py
@@ -1,13 +1,16 @@
 """Pluggable HTTP transport layer.
 
-Provides a single :func:`default_session` factory that returns either a
-``requests.Session`` (default) or a ``curl_cffi.requests.Session`` when
-the ``TUTUBO_TRANSPORT`` env var is set to ``curl_cffi`` and the
-``curl_cffi`` package is importable (install via ``pip install
+Provides a single :func:`default_session` factory. When
+``TUTUBO_TRANSPORT=curl_cffi`` and ``curl_cffi`` is importable it returns a
+``curl_cffi.requests.Session`` impersonating Chrome. Otherwise it returns an
+``unblock_requests.CloudflareSession`` when that package is importable, and a
+plain ``requests.Session`` as a final fallback. All variants are drop-in
+``requests.Session`` instances (install extras via ``pip install
 tutubo[stealth]``).
 
-The curl_cffi transport mimics real-browser TLS/HTTP fingerprints, which
-helps evade bot detection on YouTube channel HTML pages.
+The curl_cffi transport mimics real-browser TLS/HTTP fingerprints and
+``CloudflareSession`` adds anti-bot routing with a Wayback fallback, both of
+which help evade bot detection on YouTube channel HTML pages.
 
 Note: ``tutubo._innertube._post`` uses stdlib ``urllib.request`` and is
 intentionally outside this abstraction — sessions injected here do not
@@ -47,5 +50,11 @@ def default_session() -> Any:
                 "TUTUBO_TRANSPORT=curl_cffi but curl_cffi is not installed; "
                 "falling back to requests. Install with `pip install tutubo[stealth]`."
             )
-    import requests
-    return requests.Session()
+    try:
+        from unblock_requests import CloudflareSession
+
+        return CloudflareSession(env_prefix="TUTUBO", wayback_fallback=True)
+    except Exception:
+        import requests
+
+        return requests.Session()


### PR DESCRIPTION
Routes the transport through `unblock_requests.CloudflareSession` via a non-breaking soft-import (graceful fallback to the existing session). Added to an optional extra, not core deps. Parse layer/public API unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)